### PR TITLE
Defined datasource host and port as variable in API configuration file

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -37,7 +37,7 @@ swagger-ui:
 
 datasources:
   default:
-    url: jdbc:mysql://localhost:53307/demo?useUnicode=yes&characterEncoding=UTF-8
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:53307}/demo?useUnicode=yes&characterEncoding=UTF-8
     username: demo
     password: demo
     driverClassName: org.mariadb.jdbc.Driver


### PR DESCRIPTION
For a workshop, I wanted to be able to run all container inside the same docker-compose file. It requires to modify the datasource host and port configuration using env vars.